### PR TITLE
[MAT-476] Enable FOSSA Scans

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,10 @@
-@Library('pipeline-library-java@5.0.2') _
+@Library('pipeline-library-java@feature/mat-476-fossa-scans') _
 
 pipelineLibraryJava(
-        channel: '#outbound-pipeline',
-        bomAutoUpdate: false,
-        sonarQube: false,
-        sonarQubePR: false
+    channel: '#outbound-pipeline',
+    bomAutoUpdate: false,
+    sonarQube: false,
+    sonarQubePR: false,
+    shouldFossaScan: true,
+    fossaScanOptions: [debug: true]
 )


### PR DESCRIPTION
This pull enables FOSSA scanning for the outbound-disl-mit repo based on a custom branch of collibra/jenkins-pipeline-library-java and the `Jenkinsfile` should be updated to point to a released version of the pipeline library in a future PR once https://github.com/collibra/jenkins-pipeline-library-java/pull/15 is merged, tagged, and released.