### PR TITLE
[RI-2125] Use pipeline-library-java 6.0.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('pipeline-library-java@feature/mat-476-fossa-scans') _
+@Library('pipeline-library-java@6.0.7') _
 
 pipelineLibraryJava(
     channel: '#outbound-pipeline',


### PR DESCRIPTION
Now that https://github.com/collibra/jenkins-pipeline-library-java/pull/15 was merged and tagged, we can switch to using release [6.0.7](https://github.com/collibra/jenkins-pipeline-library-java/releases/tag/6.0.7) of the pipeline.